### PR TITLE
Change DdbStreamEventInfo type to a union change

### DIFF
--- a/lambda/types.js
+++ b/lambda/types.js
@@ -52,7 +52,10 @@ export type DdbStreamEventInfo
     ApproximateCreationDateTime: number,
     Keys: DynamoDbItem,
     NewImage: DynamoDbItem,
-    OldImage: DynamoDbItem
+  } | {
+    ApproximateCreationDateTime: number,
+    Keys: DynamoDbItem,
+    OldImage: DynamoDbItem,
   }
 
 export type KinesisStreamEvent


### PR DESCRIPTION
Update DdbStreamEventInfo field to allow either:

a) NewImage and OldImage fields
b) only NewImage field
c) only OldImage field