### PR TITLE
Separated out the 'DdbStreamEventRecord' type

### DIFF
--- a/lambda/types.js
+++ b/lambda/types.js
@@ -40,11 +40,14 @@ export type ApiProxiedEvent = {
 
 export type DdbStreamEvent
     = {
-        Records: Array<{
-            dynamodb: DdbStreamEventInfo,
-            eventName: 'INSERT' | 'MODIFY' | 'REMOVE',
-            eventSourceARN: string
-        }>
+        Records: Array<DdbStreamEventRecord>
+    }
+
+export type DdbStreamEventRecord
+    = {
+        dynamodb: DdbStreamEventInfo,
+        eventName: 'INSERT' | 'MODIFY' | 'REMOVE',
+        eventSourceARN: string
     }
 
 export type DdbStreamEventInfo


### PR DESCRIPTION
To avoid having to extract out `$ElementType<$PropertyType<DdbStreamEvent, 'Records'>, number>`